### PR TITLE
Add time navigation controls for comet tracker

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import axios from 'axios';
+import { initUI } from './ui.js';
 
 const AU = 149597870.7; // kilometers per astronomical unit
 
@@ -48,8 +49,7 @@ async function init() {
   const comet = new THREE.Mesh(cometGeometry, cometMaterial);
   scene.add(comet);
 
-  function updateCometPosition() {
-    const now = new Date();
+  function updateCometPosition(now = new Date()) {
 
     if (now <= ephemeris[0].time) {
       comet.position.copy(pathPoints[0]);
@@ -73,9 +73,18 @@ async function init() {
     }
   }
 
+  const ui = initUI(
+    ephemeris[0].time,
+    ephemeris[ephemeris.length - 1].time,
+    updateCometPosition
+  );
+
+  setInterval(() => {
+    ui.updateCurrentTime(new Date());
+  }, 5000);
+
   function animate() {
     requestAnimationFrame(animate);
-    updateCometPosition();
     controls.update();
     renderer.render(scene, camera);
   }

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,67 @@
+export function initUI(startTime, endTime, onTimeChange) {
+  const container = document.createElement('div');
+  container.style.position = 'absolute';
+  container.style.top = '10px';
+  container.style.left = '10px';
+  container.style.background = 'rgba(0, 0, 0, 0.5)';
+  container.style.padding = '10px';
+  container.style.color = '#fff';
+  container.style.fontFamily = 'sans-serif';
+
+  const playPauseBtn = document.createElement('button');
+  playPauseBtn.id = 'play-pause';
+  playPauseBtn.textContent = 'Pause';
+  container.appendChild(playPauseBtn);
+
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.id = 'date-slider';
+  slider.min = startTime.getTime();
+  slider.max = endTime.getTime();
+  slider.step = 24 * 60 * 60 * 1000; // one day
+  slider.value = Math.min(Math.max(Date.now(), startTime.getTime()), endTime.getTime());
+  slider.style.width = '300px';
+  slider.style.marginLeft = '10px';
+  container.appendChild(slider);
+
+  const dateDisplay = document.createElement('div');
+  dateDisplay.id = 'current-date';
+  dateDisplay.style.marginTop = '8px';
+  container.appendChild(dateDisplay);
+
+  document.body.appendChild(container);
+
+  let playing = true;
+  let currentTime = new Date(Number(slider.value));
+  dateDisplay.textContent = currentTime.toISOString();
+  onTimeChange(currentTime);
+
+  playPauseBtn.addEventListener('click', () => {
+    playing = !playing;
+    playPauseBtn.textContent = playing ? 'Pause' : 'Play';
+  });
+
+  slider.addEventListener('input', () => {
+    playing = false;
+    playPauseBtn.textContent = 'Play';
+    currentTime = new Date(Number(slider.value));
+    dateDisplay.textContent = currentTime.toISOString();
+    onTimeChange(currentTime);
+  });
+
+  function updateCurrentTime(now) {
+    if (!playing) return;
+    const clamped = new Date(
+      Math.min(Math.max(now.getTime(), startTime.getTime()), endTime.getTime())
+    );
+    currentTime = clamped;
+    slider.value = clamped.getTime();
+    dateDisplay.textContent = clamped.toISOString();
+    onTimeChange(clamped);
+  }
+
+  return {
+    updateCurrentTime,
+    getCurrentTime: () => currentTime,
+  };
+}


### PR DESCRIPTION
## Summary
- add UI module with play/pause and date slider
- update comet position on a timed interval using current timestamps
- synchronize displayed time with comet position

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ae74d1e08327af18bb715dbf55b5